### PR TITLE
LRNT-005: Power on for Back-End and Front-End

### DIFF
--- a/configuration.tf
+++ b/configuration.tf
@@ -1,6 +1,6 @@
 locals {
   zone_prefix = tomap({
-    production  = ""
+    production  = "ulises."
     default     = ""
     staging     = "test."
     development = "beta."
@@ -19,7 +19,7 @@ locals {
       }
       dns = {
         domains = ["zatara.in"]
-        zones   = []
+        zones   = ["${local.zone_prefix[terraform.workspace]}zatara.in"]
       }
     })
   })

--- a/dns.tf
+++ b/dns.tf
@@ -1,3 +1,12 @@
+locals {
+  name_servers = [
+    "ns-11.awsdns-01.com",
+    "ns-1146.awsdns-15.org",
+    "ns-1999.awsdns-57.co.uk",
+    "ns-887.awsdns-46.net",
+  ]
+}
+
 resource "aws_route53_delegation_set" "dns" {
   reference_name = "Delegation Set (${terraform.workspace})"
 }
@@ -7,7 +16,7 @@ resource "aws_route53domains_registered_domain" "realm" {
   domain_name = each.value
 
   dynamic "name_server" {
-    for_each = toset(aws_route53_delegation_set.dns.name_servers)
+    for_each = toset(terraform.workspace == "default" ? aws_route53_delegation_set.dns.name_servers : local.name_servers)
     content {
       name = name_server.value
     }
@@ -17,7 +26,7 @@ resource "aws_route53domains_registered_domain" "realm" {
 resource "aws_route53_zone" "kingdom" {
   for_each          = toset(local.configuration.dns.zones)
   name              = each.value
-  delegation_set_id = aws_route53_delegation_set.dns.id
+  delegation_set_id = terraform.workspace == "default" ? aws_route53_delegation_set.dns.id : null
 }
 
 locals {

--- a/dns.tf
+++ b/dns.tf
@@ -1,12 +1,3 @@
-locals {
-  name_servers = [
-    "ns-11.awsdns-01.com",
-    "ns-1146.awsdns-15.org",
-    "ns-1999.awsdns-57.co.uk",
-    "ns-887.awsdns-46.net",
-  ]
-}
-
 resource "aws_route53_delegation_set" "dns" {
   reference_name = "Delegation Set (${terraform.workspace})"
 }
@@ -16,7 +7,7 @@ resource "aws_route53domains_registered_domain" "realm" {
   domain_name = each.value
 
   dynamic "name_server" {
-    for_each = toset(terraform.workspace == "default" ? aws_route53_delegation_set.dns.name_servers : local.name_servers)
+    for_each = aws_route53_delegation_set.dns.name_servers
     content {
       name = name_server.value
     }
@@ -26,7 +17,7 @@ resource "aws_route53domains_registered_domain" "realm" {
 resource "aws_route53_zone" "kingdom" {
   for_each          = toset(local.configuration.dns.zones)
   name              = each.value
-  delegation_set_id = terraform.workspace == "default" ? aws_route53_delegation_set.dns.id : null
+  delegation_set_id = aws_route53_delegation_set.dns.id
 }
 
 locals {

--- a/dns.tf
+++ b/dns.tf
@@ -20,6 +20,22 @@ resource "aws_route53_zone" "kingdom" {
   delegation_set_id = aws_route53_delegation_set.dns.id
 }
 
+data "aws_route53_zone" "realm" {
+  for_each = toset(local.configuration.dns.zones)
+  provider = aws.root
+  name     = trimprefix(each.value, local.zone_prefix[terraform.workspace])
+}
+
+resource "aws_route53_record" "kingdom" {
+  for_each = toset(local.configuration.dns.zones)
+  provider = aws.root
+  zone_id  = data.aws_route53_zone.realm[each.value].zone_id
+  name     = each.value
+  type     = "NS"
+  ttl      = 172800
+  records  = aws_route53_zone.kingdom[each.value].name_servers
+}
+
 locals {
   kingdom = one(values(aws_route53_zone.kingdom))
 }

--- a/dns.tf
+++ b/dns.tf
@@ -7,7 +7,7 @@ resource "aws_route53domains_registered_domain" "realm" {
   domain_name = each.value
 
   dynamic "name_server" {
-    for_each = aws_route53_delegation_set.dns.name_servers
+    for_each = toset(aws_route53_delegation_set.dns.name_servers)
     content {
       name = name_server.value
     }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ module "mycv" {
   name     = "curriculum-vitae"
   prefix   = "cv"
   zone_id  = local.kingdom.zone_id
+  domain   = local.kingdom.name
   vpc_id   = local.vpc.id
   subnets  = local.subnets.*.id
 }

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -40,12 +40,64 @@ resource "aws_lb_target_group" "back-end-workers" {
   }
 }
 
-resource "aws_lb_listener" "listener" {
+resource "aws_lb_listener" "api-listener" {
   load_balancer_arn = aws_alb.back-end.arn # Referencing our load balancer
   protocol          = "HTTP"
   port              = 80
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.back-end-workers.arn # Referencing our target group
+  }
+}
+
+resource "aws_alb" "front-end" {
+  name               = "${var.prefix}-web-alb" # Naming our load balancer
+  load_balancer_type = "application"
+
+  # Referencing the default subnets
+  subnets = var.subnets
+  # Referencing the security group
+  security_groups = [
+    aws_security_group.front-end-entry-point.id,
+  ]
+}
+
+# Creating a security group for the load balancer:
+resource "aws_security_group" "front-end-entry-point" {
+  ingress {
+    from_port   = 80 # Allowing traffic in from port 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
+  }
+
+  egress {
+    from_port   = 0             # Allowing any incoming port
+    to_port     = 0             # Allowing any outgoing port
+    protocol    = "-1"          # Allowing any outgoing protocol 
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
+  }
+}
+
+resource "aws_lb_target_group" "front-end-workers" {
+  name        = "${var.prefix}-front-end-workers"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id # Referencing the default VPC
+
+  health_check {
+    matcher = "200,301,302"
+    path    = "/"
+  }
+}
+
+resource "aws_lb_listener" "web-listener" {
+  load_balancer_arn = aws_alb.front-end.arn # Referencing our load balancer
+  protocol          = "HTTP"
+  port              = 80
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.front-end-workers.arn # Referencing our target group
   }
 }

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -1,5 +1,4 @@
-/**
-resource "aws_alb" "portfolio" {
+resource "aws_alb" "back-end" {
   name               = "${var.prefix}-alb" # Naming our load balancer
   load_balancer_type = "application"
 
@@ -7,12 +6,12 @@ resource "aws_alb" "portfolio" {
   subnets = var.subnets
   # Referencing the security group
   security_groups = [
-    aws_security_group.alb-entry-point-access.id,
+    aws_security_group.back-end-entry-point.id,
   ]
 }
 
 # Creating a security group for the load balancer:
-resource "aws_security_group" "alb-entry-point-access" {
+resource "aws_security_group" "back-end-entry-point" {
   ingress {
     from_port   = 80 # Allowing traffic in from port 80
     to_port     = 80
@@ -28,8 +27,8 @@ resource "aws_security_group" "alb-entry-point-access" {
   }
 }
 
-resource "aws_lb_target_group" "workers" {
-  name        = "${var.prefix}-workers"
+resource "aws_lb_target_group" "back-end-workers" {
+  name        = "${var.prefix}-back-end-workers"
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"
@@ -42,12 +41,11 @@ resource "aws_lb_target_group" "workers" {
 }
 
 resource "aws_lb_listener" "listener" {
-  load_balancer_arn = aws_alb.portfolio.arn # Referencing our load balancer
+  load_balancer_arn = aws_alb.back-end.arn # Referencing our load balancer
   protocol          = "HTTP"
   port              = 80
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.workers.arn # Referencing our target group
+    target_group_arn = aws_lb_target_group.back-end-workers.arn # Referencing our target group
   }
 }
-/**/

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -1,5 +1,5 @@
 resource "aws_alb" "back-end" {
-  name               = "${var.prefix}-alb" # Naming our load balancer
+  name               = "${var.prefix}-api-alb" # Naming our load balancer
   load_balancer_type = "application"
 
   # Referencing the default subnets

--- a/portfolio/dns.tf
+++ b/portfolio/dns.tf
@@ -1,15 +1,15 @@
-/**
 resource "aws_route53_record" "api" {
   zone_id = var.zone_id
   name    = "api"
   type    = "A"
   alias {
-    zone_id                = aws_alb.portfolio.zone_id
-    name                   = aws_alb.portfolio.dns_name
+    zone_id                = aws_alb.back-end.zone_id
+    name                   = aws_alb.back-end.dns_name
     evaluate_target_health = true
   }
 }
 
+/**
 resource "aws_route53_record" "root" {
   zone_id = var.zone_id
   name    = ""

--- a/portfolio/dns.tf
+++ b/portfolio/dns.tf
@@ -14,8 +14,8 @@ resource "aws_route53_record" "root" {
   name    = ""
   type    = "A"
   alias {
-    zone_id                = aws_alb.back-end.zone_id
-    name                   = aws_alb.back-end.dns_name
+    zone_id                = aws_alb.front-end.zone_id
+    name                   = aws_alb.front-end.dns_name
     evaluate_target_health = true
   }
 }

--- a/portfolio/dns.tf
+++ b/portfolio/dns.tf
@@ -9,15 +9,13 @@ resource "aws_route53_record" "api" {
   }
 }
 
-/**
 resource "aws_route53_record" "root" {
   zone_id = var.zone_id
   name    = ""
   type    = "A"
   alias {
-    zone_id                = aws_alb.portfolio.zone_id
-    name                   = aws_alb.portfolio.dns_name
+    zone_id                = aws_alb.back-end.zone_id
+    name                   = aws_alb.back-end.dns_name
     evaluate_target_health = true
   }
 }
-/**/

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -119,3 +119,70 @@ resource "aws_security_group" "api-access" {
     cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
   }
 }
+
+data "template_file" "front-end-task-definition" {
+  template = file("${path.module}/task-definition.json.tpl")
+  vars = {
+    CONTAINER = local.web_container
+    IMAGE     = replace(aws_ecr_repository.image.repository_url, "https://", "")
+    TAG       = "front-end"
+    PORT      = 3000
+  }
+}
+
+resource "aws_ecs_task_definition" "web-run" {
+  family                   = local.web_container # Naming our first task
+  container_definitions    = data.template_file.front-end-task-definition.rendered
+  requires_compatibilities = ["FARGATE"] # Stating that we are using ECS Fargate
+  network_mode             = "awsvpc"    # Using awsvpc as our network mode as this is required for Fargate
+  memory                   = 512         # Specifying the memory our container requires
+  cpu                      = 256         # Specifying the CPU our container requires
+  execution_role_arn       = aws_iam_role.task-runner.arn
+  task_role_arn            = aws_iam_role.task-command-executor.arn
+}
+
+resource "aws_ecs_service" "web" {
+  name    = "${var.prefix}-web"
+  cluster = aws_ecs_cluster.portfolio.id
+
+  # Referencing the task our service will spin up
+  task_definition        = aws_ecs_task_definition.web-run.arn
+  launch_type            = "FARGATE"
+  enable_execute_command = true
+  desired_count          = 2
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.front-end-workers.arn
+    container_name   = aws_ecs_task_definition.web-run.family
+    container_port   = 3000
+  }
+
+  network_configuration {
+    assign_public_ip = true
+    subnets          = var.subnets
+
+    security_groups = [
+      aws_security_group.web-access.id,
+    ]
+  }
+}
+
+resource "aws_security_group" "web-access" {
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    # Only allowing traffic in from the load balancer security group
+    security_groups = [
+      aws_security_group.front-end-entry-point.id,
+    ]
+  }
+
+  egress {
+    from_port   = 0             # Allowing any incoming port
+    to_port     = 0             # Allowing any outgoing port
+    protocol    = "-1"          # Allowing any outgoing protocol 
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
+  }
+}

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -126,7 +126,7 @@ data "template_file" "front-end-task-definition" {
     CONTAINER = local.web_container
     IMAGE     = replace(aws_ecr_repository.image.repository_url, "https://", "")
     TAG       = "front-end"
-    PORT      = 3000
+    PORT      = 5000
   }
 }
 
@@ -154,7 +154,7 @@ resource "aws_ecs_service" "web" {
   load_balancer {
     target_group_arn = aws_lb_target_group.front-end-workers.arn
     container_name   = aws_ecs_task_definition.web-run.family
-    container_port   = 3000
+    container_port   = 5000
   }
 
   network_configuration {

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -18,6 +18,7 @@ data "template_file" "back-end-task-definition" {
     IMAGE     = replace(aws_ecr_repository.image.repository_url, "https://", "")
     TAG       = "back-end"
     PORT      = 3000
+    API_URL   = "http://api.${var.domain}"
   }
 }
 
@@ -127,6 +128,7 @@ data "template_file" "front-end-task-definition" {
     IMAGE     = replace(aws_ecr_repository.image.repository_url, "https://", "")
     TAG       = "front-end"
     PORT      = 5000
+    API_URL   = "http://api.${var.domain}"
   }
 }
 

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -19,6 +19,7 @@ data "template_file" "back-end-task-definition" {
     TAG       = "back-end"
     PORT      = 3000
     API_URL   = "http://api.${var.domain}"
+    CONTROL   = "RAILS_ENV"
   }
 }
 
@@ -129,6 +130,8 @@ data "template_file" "front-end-task-definition" {
     TAG       = "front-end"
     PORT      = 5000
     API_URL   = "http://api.${var.domain}"
+    CONTROL   = "NODE_ENV"
+
   }
 }
 

--- a/portfolio/task-definition.json.tpl
+++ b/portfolio/task-definition.json.tpl
@@ -13,6 +13,10 @@
 			{
 				"name": "NODE_ENV",
 				"value": "production"
+			},
+			{
+				"name": "RAILS_ENV",
+				"value": "production"
 			}
 		],
 		"portMappings": [

--- a/portfolio/task-definition.json.tpl
+++ b/portfolio/task-definition.json.tpl
@@ -8,8 +8,8 @@
 		"environment": [],
 		"portMappings": [
 			{
-				"containerPort": $PORT,
-				"hostPort": $PORT
+				"containerPort": ${PORT},
+				"hostPort": ${PORT}
 			}
 		],
 		"linuxParameters": {

--- a/portfolio/task-definition.json.tpl
+++ b/portfolio/task-definition.json.tpl
@@ -9,6 +9,10 @@
 			{
 				"name": "API_URL",
 				"value": "${API_URL}"
+			},
+			{
+				"name": "NODE_ENV",
+				"value": "production"
 			}
 		],
 		"portMappings": [

--- a/portfolio/task-definition.json.tpl
+++ b/portfolio/task-definition.json.tpl
@@ -5,7 +5,12 @@
 		"memory": 512,
 		"cpu": 256,
 		"image": "${IMAGE}:${TAG}",
-		"environment": [],
+		"environment": [
+			{
+				"name": "API_URL",
+				"value": "${API_URL}"
+			}
+		],
 		"portMappings": [
 			{
 				"containerPort": ${PORT},

--- a/portfolio/task-definition.json.tpl
+++ b/portfolio/task-definition.json.tpl
@@ -11,11 +11,7 @@
 				"value": "${API_URL}"
 			},
 			{
-				"name": "NODE_ENV",
-				"value": "production"
-			},
-			{
-				"name": "RAILS_ENV",
+				"name": "${CONTROL}",
 				"value": "production"
 			}
 		],

--- a/portfolio/variables.tf
+++ b/portfolio/variables.tf
@@ -12,6 +12,10 @@ variable "zone_id" {
   type = string
 }
 
+variable "domain" {
+  type = string
+}
+
 variable "vpc_id" {
   type = string
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,3 +7,8 @@ provider "aws" {
     }
   }
 }
+
+provider "aws" {
+  region = var.aws_region
+  alias  = "root"
+}


### PR DESCRIPTION
## 🧑‍💻 Description
These changes provision and enable the infrastructure for back-end and front-end of the curriculum website. Following is the summary of the main changes:
 * Application Load Balancer for both ends
 * Load Balancer Listener for both ends
 * Security groups for both ends and their Load Balancers
 * IAM Policy for Task Runner and Command Executor
 * DNS records for both ends
 * ECS Task definition for both containers
 * Adding environment variable for API URL
 * Fix for production sub-domain name
 * Adding zone and DNS records on main account to route the sub-zones
 * New AWS provider alias to access the main account from workspaces

## ✅ Testing
I used the development AWS account to confirm the infrastructure was provisioned correctly via the GitHub Actions.

## 🖼️ Evidence
Following screenshot shows both services were deployed into AWS ECS in `development` account:
![image](https://github.com/zatarain/lorentz/assets/539783/169c6879-8445-4fbe-b6c5-d735de8d8ccf)

Also confirmed in `staging` account:
![image](https://github.com/zatarain/lorentz/assets/539783/8f56fc9c-64ae-4ef6-aca4-d6cc59e5335d)

## 🔀 Related Pull Requests
 * [PORT-005: Power on for Back-End and Front-End](https://github.com/zatarain/portfolio/pull/5)
