### PR TITLE
LRNT-008: Secure listener for Load Balancers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 module "mycv" {
-  for_each = toset(local.configuration.sdlc.environments)
-  source   = "./portfolio"
-  name     = "curriculum-vitae"
-  prefix   = "cv"
-  zone_id  = local.kingdom.zone_id
-  domain   = local.kingdom.name
-  vpc_id   = local.vpc.id
-  subnets  = local.subnets.*.id
-  #certificate = aws_acm_certificate.kingdom.arn
+  for_each    = toset(local.configuration.sdlc.environments)
+  source      = "./portfolio"
+  name        = "curriculum-vitae"
+  prefix      = "cv"
+  zone_id     = local.kingdom.zone_id
+  domain      = local.kingdom.name
+  vpc_id      = local.vpc.id
+  subnets     = local.subnets.*.id
+  certificate = data.aws_acm_certificate.kingdom[local.kingdom.name].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -7,5 +7,5 @@ module "mycv" {
   domain      = local.kingdom.name
   vpc_id      = local.vpc.id
   subnets     = local.subnets.*.id
-  certificate = data.aws_acm_certificate.kingdom[local.kingdom.name].arn
+  certificate = aws_acm_certificate.kingdom[local.kingdom.name].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,13 @@
 module "mycv" {
-  for_each    = toset(local.configuration.sdlc.environments)
-  source      = "./portfolio"
-  name        = "curriculum-vitae"
-  prefix      = "cv"
-  zone_id     = local.kingdom.zone_id
-  domain      = local.kingdom.name
-  vpc_id      = local.vpc.id
-  subnets     = local.subnets.*.id
-  certificate = aws_acm_certificate.kingdom[local.kingdom.name].arn
+  for_each = toset(local.configuration.sdlc.environments)
+  source   = "./portfolio"
+  name     = "curriculum-vitae"
+  prefix   = "cv"
+  zone_id  = local.kingdom.zone_id
+  domain   = local.kingdom.name
+  vpc_id   = local.vpc.id
+  subnets  = local.subnets.*.id
+
+  wildcard-certificate = aws_acm_certificate.kingdom[local.kingdom.name].arn
+  apex-certificate     = aws_acm_certificate.realm[local.kingdom.name].arn
 }

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -45,11 +45,15 @@ resource "aws_lb_listener" "api-listener" {
   protocol          = "HTTP"
   port              = 80
   default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.back-end-workers.arn
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
-/**
+
 resource "aws_lb_listener" "api-secure-listener" {
   load_balancer_arn = aws_alb.back-end.arn
   protocol          = "HTTPS"
@@ -61,7 +65,7 @@ resource "aws_lb_listener" "api-secure-listener" {
     target_group_arn = aws_lb_target_group.back-end-workers.arn
   }
 }
-/**/
+
 resource "aws_alb" "front-end" {
   name               = "${var.prefix}-web-alb" # Naming our load balancer
   load_balancer_type = "application"
@@ -109,11 +113,15 @@ resource "aws_lb_listener" "web-listener" {
   protocol          = "HTTP"
   port              = 80
   default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.front-end-workers.arn
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
-/**
+
 resource "aws_lb_listener" "web-secure-listener" {
   load_balancer_arn = aws_alb.front-end.arn
   protocol          = "HTTPS"
@@ -125,4 +133,3 @@ resource "aws_lb_listener" "web-secure-listener" {
     target_group_arn = aws_lb_target_group.front-end-workers.arn
   }
 }
-/**/

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -94,6 +94,13 @@ resource "aws_security_group" "front-end-entry-point" {
     cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
   }
 
+  ingress {
+    from_port   = 443 # Allowing traffic in from port 80
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
+  }
+
   egress {
     from_port   = 0             # Allowing any incoming port
     to_port     = 0             # Allowing any outgoing port

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -59,7 +59,7 @@ resource "aws_lb_listener" "api-secure-listener" {
   protocol          = "HTTPS"
   port              = 443
   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-  certificate_arn   = var.certificate
+  certificate_arn   = var.wildcard-certificate
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.back-end-workers.arn
@@ -127,7 +127,7 @@ resource "aws_lb_listener" "web-secure-listener" {
   protocol          = "HTTPS"
   port              = 443
   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-  certificate_arn   = var.certificate
+  certificate_arn   = var.apex-certificate
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.front-end-workers.arn

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -56,9 +56,9 @@ resource "aws_lb_listener" "api-listener" {
 
 resource "aws_lb_listener" "api-secure-listener" {
   load_balancer_arn = aws_alb.back-end.arn
-  protocol          = "TLS"
+  protocol          = "HTTPS"
   port              = 443
-  alpn_policy       = "HTTP2Preferred"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = var.certificate
   default_action {
     type             = "forward"
@@ -124,9 +124,9 @@ resource "aws_lb_listener" "web-listener" {
 
 resource "aws_lb_listener" "web-secure-listener" {
   load_balancer_arn = aws_alb.front-end.arn
-  protocol          = "TLS"
+  protocol          = "HTTPS"
   port              = 443
-  alpn_policy       = "HTTP2Preferred"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = var.certificate
   default_action {
     type             = "forward"

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -56,9 +56,9 @@ resource "aws_lb_listener" "api-listener" {
 
 resource "aws_lb_listener" "api-secure-listener" {
   load_balancer_arn = aws_alb.back-end.arn
-  protocol          = "HTTPS"
+  protocol          = "TLS"
   port              = 443
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  alpn_policy       = "HTTP2Preferred"
   certificate_arn   = var.certificate
   default_action {
     type             = "forward"
@@ -124,9 +124,9 @@ resource "aws_lb_listener" "web-listener" {
 
 resource "aws_lb_listener" "web-secure-listener" {
   load_balancer_arn = aws_alb.front-end.arn
-  protocol          = "HTTPS"
+  protocol          = "TLS"
   port              = 443
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  alpn_policy       = "HTTP2Preferred"
   certificate_arn   = var.certificate
   default_action {
     type             = "forward"

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -29,8 +29,8 @@ resource "aws_security_group" "back-end-entry-point" {
 
 resource "aws_lb_target_group" "back-end-workers" {
   name        = "${var.prefix}-back-end-workers"
-  port        = 80
-  protocol    = "HTTP"
+  port        = 443
+  protocol    = "HTTPS"
   target_type = "ip"
   vpc_id      = var.vpc_id # Referencing the default VPC
 

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -19,6 +19,13 @@ resource "aws_security_group" "back-end-entry-point" {
     cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
   }
 
+  ingress {
+    from_port   = 443 # Allowing traffic in from port 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
+  }
+
   egress {
     from_port   = 0             # Allowing any incoming port
     to_port     = 0             # Allowing any outgoing port
@@ -29,8 +36,8 @@ resource "aws_security_group" "back-end-entry-point" {
 
 resource "aws_lb_target_group" "back-end-workers" {
   name        = "${var.prefix}-back-end-workers"
-  port        = 443
-  protocol    = "HTTPS"
+  port        = 80
+  protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = var.vpc_id # Referencing the default VPC
 

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -18,7 +18,7 @@ data "template_file" "back-end-task-definition" {
     IMAGE     = replace(aws_ecr_repository.image.repository_url, "https://", "")
     TAG       = "back-end"
     PORT      = 3000
-    API_URL   = "http://api.${var.domain}"
+    API_URL   = "https://api.${var.domain}"
     CONTROL   = "RAILS_ENV"
   }
 }
@@ -117,7 +117,7 @@ resource "aws_security_group" "api-access" {
   egress {
     from_port   = 0             # Allowing any incoming port
     to_port     = 0             # Allowing any outgoing port
-    protocol    = "-1"          # Allowing any outgoing protocol 
+    protocol    = "-1"          # Allowing any outgoing protocol
     cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
   }
 }
@@ -129,7 +129,7 @@ data "template_file" "front-end-task-definition" {
     IMAGE     = replace(aws_ecr_repository.image.repository_url, "https://", "")
     TAG       = "front-end"
     PORT      = 5000
-    API_URL   = "http://api.${var.domain}"
+    API_URL   = "https://api.${var.domain}"
     CONTROL   = "NODE_ENV"
 
   }
@@ -187,7 +187,7 @@ resource "aws_security_group" "web-access" {
   egress {
     from_port   = 0             # Allowing any incoming port
     to_port     = 0             # Allowing any outgoing port
-    protocol    = "-1"          # Allowing any outgoing protocol 
+    protocol    = "-1"          # Allowing any outgoing protocol
     cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
   }
 }

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -131,7 +131,6 @@ data "template_file" "front-end-task-definition" {
     PORT      = 5000
     API_URL   = "https://api.${var.domain}"
     CONTROL   = "NODE_ENV"
-
   }
 }
 

--- a/portfolio/variables.tf
+++ b/portfolio/variables.tf
@@ -24,6 +24,10 @@ variable "subnets" {
   type = list(string)
 }
 
-variable "certificate" {
+variable "wildcard-certificate" {
+  type = string
+}
+
+variable "apex-certificate" {
   type = string
 }

--- a/portfolio/variables.tf
+++ b/portfolio/variables.tf
@@ -23,8 +23,7 @@ variable "vpc_id" {
 variable "subnets" {
   type = list(string)
 }
-/**
+
 variable "certificate" {
   type = string
 }
-/**/

--- a/ssl.tf
+++ b/ssl.tf
@@ -80,11 +80,11 @@ locals {
     ]
   }
 
-	realm_validation_record_fqdns = {
+  realm_validation_record_fqdns = {
     for domain in local.configuration.dns.zones : domain => [
       for record in aws_route53_record.realm-ssl :
       record.fqdn if record.zone_id == aws_route53_zone.kingdom[domain].zone_id
-			# Filter has to be the same, as zone_id is the same for kingdom and realm
+      # Filter has to be the same, as zone_id is the same for kingdom and realm
     ]
   }
 }

--- a/ssl.tf
+++ b/ssl.tf
@@ -8,17 +8,6 @@ resource "aws_acm_certificate" "kingdom" {
   }
 }
 
-resource "aws_acm_certificate" "realm" {
-  for_each          = toset(local.configuration.dns.zones)
-  domain_name       = each.value
-  validation_method = "DNS"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-/**
 locals {
   ssl_validation_records = flatten([
     for key, certificate in aws_acm_certificate.kingdom : [

--- a/ssl.tf
+++ b/ssl.tf
@@ -62,4 +62,10 @@ resource "aws_acm_certificate_validation" "ssl" {
   certificate_arn         = aws_acm_certificate.kingdom[each.value].arn
   validation_record_fqdns = local.validation_record_fqdns[each.value]
 }
-/**/
+
+data "aws_acm_certificate" "kingdom" {
+  for_each = toset(local.configuration.dns.zones)
+  provider = aws.root
+
+  domain = replace(each.value, "/^${local.zone_prefix[terraform.workspace]}/", "*.")
+}

--- a/ssl.tf
+++ b/ssl.tf
@@ -19,8 +19,20 @@ resource "aws_acm_certificate" "realm" {
 }
 
 locals {
-  ssl_validation_records = flatten([
+  kingdom_validation_records = flatten([
     for key, certificate in aws_acm_certificate.kingdom : [
+      for option in certificate.domain_validation_options : {
+        domain  = option.domain_name
+        name    = option.resource_record_name
+        record  = option.resource_record_value
+        type    = option.resource_record_type
+        zone_id = aws_route53_zone.kingdom[key].zone_id
+      }
+    ]
+  ])
+
+  realm_validation_records = flatten([
+    for key, certificate in aws_acm_certificate.realm : [
       for option in certificate.domain_validation_options : {
         domain  = option.domain_name
         name    = option.resource_record_name
@@ -32,9 +44,23 @@ locals {
   ])
 }
 
-resource "aws_route53_record" "ssl" {
+resource "aws_route53_record" "kingdom-ssl" {
   for_each = {
-    for record in local.ssl_validation_records :
+    for record in local.kingdom_validation_records :
+    "${record.type}/${record.name}" => record
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = each.value.zone_id
+}
+
+resource "aws_route53_record" "realm-ssl" {
+  for_each = {
+    for record in local.realm_validation_records :
     "${record.type}/${record.name}" => record
   }
 
@@ -47,17 +73,32 @@ resource "aws_route53_record" "ssl" {
 }
 
 locals {
-  validation_record_fqdns = {
+  kingdom_validation_record_fqdns = {
     for domain in local.configuration.dns.zones : domain => [
-      for record in aws_route53_record.ssl :
+      for record in aws_route53_record.kingdom-ssl :
       record.fqdn if record.zone_id == aws_route53_zone.kingdom[domain].zone_id
+    ]
+  }
+
+	realm_validation_record_fqdns = {
+    for domain in local.configuration.dns.zones : domain => [
+      for record in aws_route53_record.realm-ssl :
+      record.fqdn if record.zone_id == aws_route53_zone.kingdom[domain].zone_id
+			# Filter has to be the same, as zone_id is the same for kingdom and realm
     ]
   }
 }
 
-resource "aws_acm_certificate_validation" "ssl" {
+resource "aws_acm_certificate_validation" "kingdom-ssl" {
   for_each = toset(local.configuration.dns.zones)
 
   certificate_arn         = aws_acm_certificate.kingdom[each.value].arn
-  validation_record_fqdns = local.validation_record_fqdns[each.value]
+  validation_record_fqdns = local.kingdom_validation_record_fqdns[each.value]
+}
+
+resource "aws_acm_certificate_validation" "realm-ssl" {
+  for_each = toset(local.configuration.dns.zones)
+
+  certificate_arn         = aws_acm_certificate.realm[each.value].arn
+  validation_record_fqdns = local.realm_validation_record_fqdns[each.value]
 }

--- a/ssl.tf
+++ b/ssl.tf
@@ -62,10 +62,3 @@ resource "aws_acm_certificate_validation" "ssl" {
   certificate_arn         = aws_acm_certificate.kingdom[each.value].arn
   validation_record_fqdns = local.validation_record_fqdns[each.value]
 }
-
-data "aws_acm_certificate" "kingdom" {
-  for_each = toset(local.configuration.dns.zones)
-  provider = aws.root
-
-  domain = replace(each.value, "/^${local.zone_prefix[terraform.workspace]}/", "*.")
-}

--- a/ssl.tf
+++ b/ssl.tf
@@ -8,6 +8,16 @@ resource "aws_acm_certificate" "kingdom" {
   }
 }
 
+resource "aws_acm_certificate" "realm" {
+  for_each          = toset(local.configuration.dns.zones)
+  domain_name       = each.value
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 locals {
   ssl_validation_records = flatten([
     for key, certificate in aws_acm_certificate.kingdom : [


### PR DESCRIPTION
## 🧑‍💻 Description
Adding listeners for HTTPS on port 443 on load balancers for both (front-end and back-end). These changes also create DNS validation records for all certificates on each zone/environment.

## ✅ Testing
Changes were deployed to `development` to confirm we can reach the website and the API service via HTTPS and we are using the SSL certificate.

## 🖼️ Evidence
We can see on following screenshot that `development` website is reachable via HTTPS and get the SSL certificate:
![image](https://github.com/zatarain/lorentz/assets/539783/c1d160f8-8bac-43a0-adbc-2c13fe690805)

These changes also were tested on `staging` already:
![image](https://github.com/zatarain/lorentz/assets/539783/efb60fbf-8664-4300-b190-40fd35c10f21)
