### PR TITLE
LRNT-XXX: Adding SSL certificates by zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,5 +7,5 @@ module "mycv" {
   domain   = local.kingdom.name
   vpc_id   = local.vpc.id
   subnets  = local.subnets.*.id
-  #certificate = data.aws_acm_certificate.kingdom.arn
+  #certificate = aws_acm_certificate.kingdom.arn
 }

--- a/ssl.tf
+++ b/ssl.tf
@@ -1,5 +1,5 @@
 resource "aws_acm_certificate" "kingdom" {
-  for_each          = toset(local.configuration.dns.domains)
+  for_each          = toset(local.configuration.dns.zones)
   domain_name       = "*.${each.value}"
   validation_method = "DNS"
 
@@ -7,7 +7,7 @@ resource "aws_acm_certificate" "kingdom" {
     create_before_destroy = true
   }
 }
-
+/**
 locals {
   ssl_validation_records = flatten([
     for key, certificate in aws_acm_certificate.kingdom : [
@@ -38,7 +38,7 @@ resource "aws_route53_record" "ssl" {
 
 locals {
   validation_record_fqdns = {
-    for domain in local.configuration.dns.domains : domain => [
+    for domain in local.configuration.dns.zones : domain => [
       for record in aws_route53_record.ssl :
       record.fqdn if record.zone_id == aws_route53_zone.kingdom[domain].zone_id
     ]
@@ -46,18 +46,9 @@ locals {
 }
 
 resource "aws_acm_certificate_validation" "ssl" {
-  for_each = toset(local.configuration.dns.domains)
+  for_each = toset(local.configuration.dns.zones)
 
   certificate_arn         = aws_acm_certificate.kingdom[each.value].arn
   validation_record_fqdns = local.validation_record_fqdns[each.value]
-}
-/**
-data "aws_acm_certificate" "kingdom" {
-  #for_each = toset(local.configuration.dns.zones)
-  provider = aws.root
-
-  domain = "*.zatara.in"
-  #replace(each.value, local.zone_prefix[terraform.workspace], "*.")
-  #types = ["AMAZON_ISSUED"]
 }
 /**/


### PR DESCRIPTION
## 🧑‍💻 Description
These changes aim to create an SSL certificate for each environment zone. They will also remove the validation records on the default environment for consistency, those records will be added later for all zones too.

The reason behind this is that [it's not possible to share SSL certificates between AWS accounts](https://repost.aws/knowledge-center/acm-export-certificate).

## ✅ Testing
The plan succeeded locally on `default` and `development` workspaces.