### PR TITLE
LRNT-XXX: Create certificates for apex domain name as realm

### DIFF
--- a/ssl.tf
+++ b/ssl.tf
@@ -7,6 +7,17 @@ resource "aws_acm_certificate" "kingdom" {
     create_before_destroy = true
   }
 }
+
+resource "aws_acm_certificate" "realm" {
+  for_each          = toset(local.configuration.dns.zones)
+  domain_name       = each.value
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 /**
 locals {
   ssl_validation_records = flatten([


### PR DESCRIPTION
## 🧑‍💻 Description
Given that we cannot use a wildcard certificate (`*.mydomain.com`) to protect an apex domain name (`mydomain.com`), we need to create a separate certificate for the apex domain. Further information can be found on [AWS: Create an HTTPS listener for your Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#https-listener-certificates).

These changes aim to create a separate certificate for apex domain name on each environment/zone under the identifier group `realm`. The wildcard certificates will stay under the identifier group `kingdom`.


## ✅ Testing
Changes were deployed to `development` and `staging` workspaces and confirm that both certificates were created for each environments.