### PR TITLE
LRNT-009: Unifying security groups for the application

### DIFF
--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -6,7 +6,7 @@ resource "aws_alb" "back-end" {
   subnets = var.subnets
   # Referencing the security group
   security_groups = [
-    aws_security_group.back-end-entry-point.id,
+    aws_security_group.entry-point.id,
   ]
 }
 
@@ -81,7 +81,7 @@ resource "aws_alb" "front-end" {
   subnets = var.subnets
   # Referencing the security group
   security_groups = [
-    aws_security_group.front-end-entry-point.id,
+    aws_security_group.entry-point.id,
   ]
 }
 

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -97,7 +97,7 @@ resource "aws_ecs_service" "api" {
     subnets          = var.subnets
 
     security_groups = [
-      aws_security_group.api-access.id,
+      aws_security_group.alb-access.id,
     ]
   }
 }
@@ -166,7 +166,7 @@ resource "aws_ecs_service" "web" {
     subnets          = var.subnets
 
     security_groups = [
-      aws_security_group.web-access.id,
+      aws_security_group.alb-access.id,
     ]
   }
 }

--- a/portfolio/security.tf
+++ b/portfolio/security.tf
@@ -1,0 +1,43 @@
+# Creating a security group for load balancers
+resource "aws_security_group" "entry-point" {
+  ingress {
+    from_port   = 80 # Allowing traffic in from port 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
+  }
+
+  ingress {
+    from_port   = 443 # Allowing traffic in from port 80
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
+  }
+
+  egress {
+    from_port   = 0             # Allowing any incoming port
+    to_port     = 0             # Allowing any outgoing port
+    protocol    = "-1"          # Allowing any outgoing protocol
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
+  }
+}
+
+resource "aws_security_group" "alb-access" {
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    # Only allowing traffic in from load balancers security group
+    security_groups = [
+      aws_security_group.entry-point.id,
+    ]
+  }
+
+  egress {
+    from_port   = 0             # Allowing any incoming port
+    to_port     = 0             # Allowing any outgoing port
+    protocol    = "-1"          # Allowing any outgoing protocol
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
+  }
+}


### PR DESCRIPTION
## 🧑‍💻 Description
These changes create a new security group for the application in order to be used by front-end and back-end. The purpose is use less AWS resources if necessary. After deploy these changes, we should remove the older security groups to keep only the new ones.

## ✅ Testing
These changes were deployed to `development` and `staging` environments and the services still working there after the deployment.