### PR TITLE
LRNT-009: Removing old security groups for the application

### DIFF
--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -10,30 +10,6 @@ resource "aws_alb" "back-end" {
   ]
 }
 
-# Creating a security group for the load balancer:
-resource "aws_security_group" "back-end-entry-point" {
-  ingress {
-    from_port   = 80 # Allowing traffic in from port 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
-  }
-
-  ingress {
-    from_port   = 443 # Allowing traffic in from port 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
-  }
-
-  egress {
-    from_port   = 0             # Allowing any incoming port
-    to_port     = 0             # Allowing any outgoing port
-    protocol    = "-1"          # Allowing any outgoing protocol
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
-  }
-}
-
 resource "aws_lb_target_group" "back-end-workers" {
   name        = "${var.prefix}-back-end-workers"
   port        = 80
@@ -83,30 +59,6 @@ resource "aws_alb" "front-end" {
   security_groups = [
     aws_security_group.entry-point.id,
   ]
-}
-
-# Creating a security group for the load balancer:
-resource "aws_security_group" "front-end-entry-point" {
-  ingress {
-    from_port   = 80 # Allowing traffic in from port 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
-  }
-
-  ingress {
-    from_port   = 443 # Allowing traffic in from port 80
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
-  }
-
-  egress {
-    from_port   = 0             # Allowing any incoming port
-    to_port     = 0             # Allowing any outgoing port
-    protocol    = "-1"          # Allowing any outgoing protocol
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
-  }
 }
 
 resource "aws_lb_target_group" "front-end-workers" {

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -102,26 +102,6 @@ resource "aws_ecs_service" "api" {
   }
 }
 
-resource "aws_security_group" "api-access" {
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-
-    # Only allowing traffic in from the load balancer security group
-    security_groups = [
-      aws_security_group.back-end-entry-point.id,
-    ]
-  }
-
-  egress {
-    from_port   = 0             # Allowing any incoming port
-    to_port     = 0             # Allowing any outgoing port
-    protocol    = "-1"          # Allowing any outgoing protocol
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
-  }
-}
-
 data "template_file" "front-end-task-definition" {
   template = file("${path.module}/task-definition.json.tpl")
   vars = {
@@ -168,25 +148,5 @@ resource "aws_ecs_service" "web" {
     security_groups = [
       aws_security_group.alb-access.id,
     ]
-  }
-}
-
-resource "aws_security_group" "web-access" {
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-
-    # Only allowing traffic in from the load balancer security group
-    security_groups = [
-      aws_security_group.front-end-entry-point.id,
-    ]
-  }
-
-  egress {
-    from_port   = 0             # Allowing any incoming port
-    to_port     = 0             # Allowing any outgoing port
-    protocol    = "-1"          # Allowing any outgoing protocol
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
   }
 }


### PR DESCRIPTION
## 🧑‍💻 Description
These changes are the second phase of [LRNT-009: Unifying security groups for the application](https://github.com/zatarain/lorentz/pull/15). So, we are removing the security groups that are no longer used by the application.

## ✅ Testing
 * The application still working after deploy changes in `development` and `staging` environments.
 * The `default` workspace is not impacted by this changes.