### PR TITLE
LRNT-012: Adding Instagram access to get pictures

### DIFF
--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -99,6 +99,11 @@ data "aws_iam_policy_document" "command-executor" {
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.instagram.arn]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "task-command-executor-policy" {
@@ -108,7 +113,6 @@ resource "aws_iam_role_policy_attachment" "task-command-executor-policy" {
 
 resource "aws_iam_role_policy_attachment" "task-executor-access-to-s3" {
   role       = aws_iam_role.task-command-executor.name
-#   #policy_arn = aws_iam_policy.s3-access.arn
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -99,11 +99,19 @@ data "aws_iam_policy_document" "command-executor" {
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
+}
 
+data "aws_iam_policy_document" "secrets-manager-access" {
   statement {
     actions = ["secretsmanager:GetSecretValue"]
     resources = [aws_secretsmanager_secret.instagram.arn]
   }
+}
+
+resource "aws_iam_policy" "secrets-access" {
+  name   = "PortfolioSecretsAccess"
+  path   = "/"
+  policy = data.aws_iam_policy_document.secrets-manager-access.json
 }
 
 resource "aws_iam_role_policy_attachment" "task-command-executor-policy" {
@@ -114,6 +122,11 @@ resource "aws_iam_role_policy_attachment" "task-command-executor-policy" {
 resource "aws_iam_role_policy_attachment" "task-executor-access-to-s3" {
   role       = aws_iam_role.task-command-executor.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "task-executor-access-to-secrets" {
+  role       = aws_iam_role.task-command-executor.name
+  policy_arn = aws_iam_policy.secrets-access.arn
 }
 
 resource "aws_ecs_service" "api" {

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -31,6 +31,24 @@ data "template_file" "back-end-task-definition" {
 				name  = "RAILS_ENV"
 				value = "production"
 			},
+      {
+        name = "INSTAGRAM_REDIRECT_URI"
+        value= "https://${var.domain}"
+      },
+    ])
+    SECRETS = jsonencode([
+      {
+        name  = "INSTAGRAM_CLIENT_ID"
+        valueFrom = "${aws_secretsmanager_secret.instagram.arn}:id::"
+      },
+      {
+        name  = "INSTAGRAM_CLIENT_SECRET"
+        valueFrom = "${aws_secretsmanager_secret.instagram.arn}:key::"
+      },
+      {
+        name  = "INSTAGRAM_ACCESS_TOKEN"
+        valueFrom = "${aws_secretsmanager_secret.instagram.arn}:token::"
+      },
     ])
   }
 }
@@ -141,6 +159,7 @@ data "template_file" "front-end-task-definition" {
 				value= "production"
 			},
     ])
+    SECRETS = jsonencode([])
   }
 }
 

--- a/portfolio/main.tf
+++ b/portfolio/main.tf
@@ -125,7 +125,7 @@ resource "aws_iam_role_policy_attachment" "task-executor-access-to-s3" {
 }
 
 resource "aws_iam_role_policy_attachment" "task-executor-access-to-secrets" {
-  role       = aws_iam_role.task-command-executor.name
+  role       = aws_iam_role.task-runner.name
   policy_arn = aws_iam_policy.secrets-access.arn
 }
 

--- a/portfolio/security.tf
+++ b/portfolio/security.tf
@@ -41,3 +41,16 @@ resource "aws_security_group" "alb-access" {
     cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
   }
 }
+
+resource "aws_secretsmanager_secret" "instagram" {
+  name = "${var.prefix}-instagram"
+}
+
+resource "aws_secretsmanager_secret_version" "instagram" {
+  secret_id     = aws_secretsmanager_secret.instagram.id
+  secret_string = jsonencode({
+    id = "change me"
+    key = "change me"
+    token = "change me"
+  })
+}

--- a/portfolio/task-definition.json.tpl
+++ b/portfolio/task-definition.json.tpl
@@ -6,6 +6,7 @@
 		"cpu": 256,
 		"image": "${IMAGE}:${TAG}",
 		"environment": ${ENVIRONMENT},
+		"secrets": ${SECRETS},
 		"portMappings": [
 			{
 				"containerPort": ${PORT},


### PR DESCRIPTION
# 👨🏽‍💻 Description
These changes aim to create the place holders for the secrets to integrate the website with Instagram and also the AWS permission policy to access those secrets from the API container.

After provision the resources from these changes, the actual secrets needs to be populated via AWS UI or AWS CLI.

# ✅ Testing
The changes were deployed to `development` and `staging` workspaces.

# 🖼️ Evidence
Following screenshot shows how the secret was created in `development` account:
![image](https://github.com/zatarain/lorentz/assets/539783/acb0ecdc-bbe7-44e2-9f2e-35977ad1998a)

And we can see that the environment variables are also linked to the container properly with the Secret ARN from Secret Manager:
![image](https://github.com/zatarain/lorentz/assets/539783/b950f63c-b3ed-4748-9c7c-e30d4234077c)

