### PR TITLE
LRNT-016: Create listeners and certificate for load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,5 +14,11 @@ module "mycv" {
   wildcard-certificate = aws_acm_certificate.entry-point[local.kingdom.name].arn
   apex-certificate     = aws_acm_certificate.entry-point[local.kingdom.name].arn
 
-  certificate = aws_acm_certificate.entry-point[local.kingdom.name]
+  certificate   = aws_acm_certificate.entry-point[local.kingdom.name]
+  load-balancer = data.aws_alb.entry-point
+
+  providers = {
+    aws      = aws
+    aws.root = aws.root
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,8 @@ module "mycv" {
     username = var.database_username
   }
 
-  wildcard-certificate = aws_acm_certificate.kingdom[local.kingdom.name].arn
-  apex-certificate     = aws_acm_certificate.realm[local.kingdom.name].arn
+  wildcard-certificate = aws_acm_certificate.entry-point[local.kingdom.name].arn
+  apex-certificate     = aws_acm_certificate.entry-point[local.kingdom.name].arn
+
+  certificate = aws_acm_certificate.entry-point[local.kingdom.name]
 }

--- a/portfolio/alb.tf
+++ b/portfolio/alb.tf
@@ -47,6 +47,24 @@ resource "aws_lb_listener" "api-secure-listener" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.back-end-workers.arn
   }
+
+  depends_on = [ var.certificate ]
+}
+
+resource "aws_lb_listener_rule" "front-end" {
+  listener_arn = aws_lb_listener.api-secure-listener.arn
+  priority     = 99
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.front-end-workers.arn
+  }
+
+  condition {
+    host_header {
+      values = [var.domain]
+    }
+  }
 }
 
 resource "aws_alb" "front-end" {
@@ -88,14 +106,14 @@ resource "aws_lb_listener" "web-listener" {
   }
 }
 
-resource "aws_lb_listener" "web-secure-listener" {
-  load_balancer_arn = aws_alb.front-end.arn
-  protocol          = "HTTPS"
-  port              = 443
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-  certificate_arn   = var.apex-certificate
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.front-end-workers.arn
-  }
-}
+# resource "aws_lb_listener" "web-secure-listener" {
+#   load_balancer_arn = aws_alb.front-end.arn
+#   protocol          = "HTTPS"
+#   port              = 443
+#   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+#   certificate_arn   = var.apex-certificate
+#   default_action {
+#     type             = "forward"
+#     target_group_arn = aws_lb_target_group.front-end-workers.arn
+#   }
+# }

--- a/portfolio/dns.tf
+++ b/portfolio/dns.tf
@@ -15,7 +15,7 @@ resource "aws_route53_record" "root" {
   type    = "A"
   alias {
     zone_id                = aws_alb.front-end.zone_id
-    name                   = aws_alb.front-end.dns_name
+    name                   = aws_alb.back-end.dns_name
     evaluate_target_health = true
   }
 }

--- a/portfolio/variables.tf
+++ b/portfolio/variables.tf
@@ -42,3 +42,9 @@ variable "postgres" {
   })
   sensitive = true
 }
+
+variable "certificate" {
+  type = object({
+    arn = string
+  })
+}

--- a/portfolio/variables.tf
+++ b/portfolio/variables.tf
@@ -48,3 +48,16 @@ variable "certificate" {
     arn = string
   })
 }
+
+variable "load-balancer" {
+  type = object({
+    arn      = string
+    dns_name = string
+  })
+}
+
+# variable "secure-entry-point" {
+#   type = object({
+#     arn      = string
+#   })
+# }

--- a/portfolio/versions.tf
+++ b/portfolio/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.5"
+      configuration_aliases = [ aws, aws.root ]
+    }
+  }
+}

--- a/ssl.tf
+++ b/ssl.tf
@@ -102,3 +102,65 @@ resource "aws_acm_certificate_validation" "realm-ssl" {
   certificate_arn         = aws_acm_certificate.realm[each.value].arn
   validation_record_fqdns = local.realm_validation_record_fqdns[each.value]
 }
+
+resource "aws_acm_certificate" "entry-point" {
+  for_each          = toset(local.configuration.dns.zones)
+  domain_name       = each.value
+  validation_method = "DNS"
+
+  subject_alternative_names = ["*.${each.value}"]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+/**/
+locals {
+  entry-point-validation-records = flatten([
+    for key, certificate in aws_acm_certificate.entry-point : [
+      for option in certificate.domain_validation_options : {
+        domain  = option.domain_name
+        name    = option.resource_record_name
+        record  = option.resource_record_value
+        type    = option.resource_record_type
+        zone_id = aws_route53_zone.kingdom[key].zone_id
+      }
+    ]
+  ])
+}
+
+output "entry-point-validation-records" {
+  value = local.entry-point-validation-records
+}
+
+/**/
+resource "aws_route53_record" "entry-point-ssl" {
+  for_each = {
+    for record in local.entry-point-validation-records :
+    "${record.type}/${record.name}/${record.domain}" => record
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = each.value.zone_id
+}
+
+locals {
+  entry-point-validation-record-fqdns = {
+    for domain in local.configuration.dns.zones : domain => [
+      for record in aws_route53_record.entry-point-ssl :
+      record.fqdn if record.zone_id == aws_route53_zone.kingdom[domain].zone_id
+    ]
+  }
+}
+
+resource "aws_acm_certificate_validation" "entry-point-ssl" {
+  for_each = toset(local.configuration.dns.zones)
+
+  certificate_arn         = aws_acm_certificate.entry-point[each.value].arn
+  validation_record_fqdns = local.entry-point-validation-record-fqdns[each.value]
+}
+/**/

--- a/ssl.tf
+++ b/ssl.tf
@@ -114,7 +114,7 @@ resource "aws_acm_certificate" "entry-point" {
   }
 }
 
-/**/
+/**
 locals {
   entry-point-validation-records = flatten([
     for key, certificate in aws_acm_certificate.entry-point : [
@@ -133,7 +133,6 @@ output "entry-point-validation-records" {
   value = local.entry-point-validation-records
 }
 
-/**/
 resource "aws_route53_record" "entry-point-ssl" {
   for_each = {
     for record in local.entry-point-validation-records :


### PR DESCRIPTION
## 👨🏽‍💻 Description

These changes create 2 listeners (HTTP and HTTPS) for the load balancer in the default account and also the certificates to be provided over HTTPS.

Also, unify the front-end and back-end under the same load balancer on each environment.

## ✅ Testing

The changes were provisioned in `development` and `staging` already without any impact.
