### PR TITLE
LRNT-018: Unifying services

### DIFF
--- a/portfolio/container-definition.json.tpl
+++ b/portfolio/container-definition.json.tpl
@@ -1,0 +1,18 @@
+{
+	"name": "${CONTAINER}",
+	"essential": true,
+	"memory": 512,
+	"cpu": 256,
+	"image": "${IMAGE}:${TAG}",
+	"environment": ${ENVIRONMENT},
+	"secrets": ${SECRETS},
+	"portMappings": [
+		{
+			"containerPort": ${PORT},
+			"hostPort": ${PORT}
+		}
+	],
+	"linuxParameters": {
+		"initProcessEnabled": true
+	}
+}

--- a/portfolio/task-definition.json.tpl
+++ b/portfolio/task-definition.json.tpl
@@ -1,20 +1,4 @@
 [
-	{
-		"name": "${CONTAINER}",
-		"essential": true,
-		"memory": 512,
-		"cpu": 256,
-		"image": "${IMAGE}:${TAG}",
-		"environment": ${ENVIRONMENT},
-		"secrets": ${SECRETS},
-		"portMappings": [
-			{
-				"containerPort": ${PORT},
-				"hostPort": ${PORT}
-			}
-		],
-		"linuxParameters": {
-			"initProcessEnabled": true
-		}
-	}
+	${SERVICE},
+	${WEBSITE}
 ]


### PR DESCRIPTION
## 👨🏽‍💻 Description

These changes aim to unify backend and frontend ECS services in a single one to reduce the AWS costs. This means they will continue operating in separate containers and separate target groups, but in a single ECS task.

## ✅ Testing

Changes were applied to `development` and `staging` accounts and the website stills working as expected.

