### PR TITLE
LRNT-020: Adding DNS validation records for Mail Service

### DIFF
--- a/mail.tf
+++ b/mail.tf
@@ -10,3 +10,42 @@ resource "aws_secretsmanager_secret_version" "crm-service" {
     dmarc = "change me"
   })
 }
+
+data "aws_secretsmanager_secret_version" "crm-current" {
+  secret_id = aws_secretsmanager_secret.crm-service.id
+}
+
+locals {
+  mail-server = terraform.workspace == "production" ? "" : trimsuffix(local.zone_prefix[terraform.workspace], ".")
+  mail-secret = jsondecode(data.aws_secretsmanager_secret_version.crm-current.secret_string)
+}
+
+resource "aws_route53_record" "crm-code" {
+  for_each = toset(local.records-for-kingdoms)
+  provider = aws.root
+  zone_id  = data.aws_route53_zone.realm[each.value].zone_id
+  name     = local.mail-server == "" ? "@" : local.mail-server
+  type     = "TXT"
+  ttl      = 172800
+  records  = [local.mail-secret["code"]]
+}
+
+resource "aws_route53_record" "crm-dkim" {
+  for_each = toset(local.records-for-kingdoms)
+  provider = aws.root
+  zone_id  = data.aws_route53_zone.realm[each.value].zone_id
+  name     = "mail._domainkey.${local.mail-server}"
+  type     = "TXT"
+  ttl      = 172800
+  records  = [local.mail-secret["dkim"]]
+}
+
+resource "aws_route53_record" "crm-dmarc" {
+  for_each = toset(local.records-for-kingdoms)
+  provider = aws.root
+  zone_id  = data.aws_route53_zone.realm[each.value].zone_id
+  name     = "_dmarc.${local.mail-server}"
+  type     = "TXT"
+  ttl      = 172800
+  records  = [local.mail-secret["dmarc"]]
+}

--- a/mail.tf
+++ b/mail.tf
@@ -22,7 +22,6 @@ locals {
 
 resource "aws_route53_record" "crm-code" {
   for_each = toset(local.configuration.sdlc.environments)
-  provider = aws.root
   zone_id  = local.kingdom.zone_id
   name     = local.mail-server == "" ? "@" : local.mail-server
   type     = "TXT"
@@ -32,7 +31,6 @@ resource "aws_route53_record" "crm-code" {
 
 resource "aws_route53_record" "crm-dkim" {
   for_each = toset(local.configuration.sdlc.environments)
-  provider = aws.root
   zone_id  = local.kingdom.zone_id
   name     = "mail._domainkey.${local.mail-server}"
   type     = "TXT"
@@ -42,7 +40,6 @@ resource "aws_route53_record" "crm-dkim" {
 
 resource "aws_route53_record" "crm-dmarc" {
   for_each = toset(local.configuration.sdlc.environments)
-  provider = aws.root
   zone_id  = local.kingdom.zone_id
   name     = "_dmarc.${local.mail-server}"
   type     = "TXT"

--- a/mail.tf
+++ b/mail.tf
@@ -16,14 +16,13 @@ data "aws_secretsmanager_secret_version" "crm-current" {
 }
 
 locals {
-  mail-server = terraform.workspace == "production" ? "" : trimsuffix(local.zone_prefix[terraform.workspace], ".zatara.in")
   mail-secret = jsondecode(data.aws_secretsmanager_secret_version.crm-current.secret_string)
 }
 
 resource "aws_route53_record" "crm-code" {
   for_each = toset(local.configuration.sdlc.environments)
   zone_id  = local.kingdom.zone_id
-  name     = local.mail-server == "" ? "@" : local.mail-server
+  name     = ""
   type     = "TXT"
   ttl      = 172800
   records  = [local.mail-secret["code"]]
@@ -32,7 +31,7 @@ resource "aws_route53_record" "crm-code" {
 resource "aws_route53_record" "crm-dkim" {
   for_each = toset(local.configuration.sdlc.environments)
   zone_id  = local.kingdom.zone_id
-  name     = "mail._domainkey.${local.mail-server}"
+  name     = "mail._domainkey"
   type     = "TXT"
   ttl      = 172800
   records  = [local.mail-secret["dkim"]]
@@ -41,7 +40,7 @@ resource "aws_route53_record" "crm-dkim" {
 resource "aws_route53_record" "crm-dmarc" {
   for_each = toset(local.configuration.sdlc.environments)
   zone_id  = local.kingdom.zone_id
-  name     = "_dmarc.${local.mail-server}"
+  name     = "_dmarc"
   type     = "TXT"
   ttl      = 172800
   records  = [local.mail-secret["dmarc"]]

--- a/mail.tf
+++ b/mail.tf
@@ -16,14 +16,14 @@ data "aws_secretsmanager_secret_version" "crm-current" {
 }
 
 locals {
-  mail-server = terraform.workspace == "production" ? "" : trimsuffix(local.zone_prefix[terraform.workspace], ".")
+  mail-server = terraform.workspace == "production" ? "" : trimsuffix(local.zone_prefix[terraform.workspace], ".zatara.in")
   mail-secret = jsondecode(data.aws_secretsmanager_secret_version.crm-current.secret_string)
 }
 
 resource "aws_route53_record" "crm-code" {
-  for_each = toset(local.records-for-kingdoms)
+  for_each = toset(local.configuration.sdlc.environments)
   provider = aws.root
-  zone_id  = data.aws_route53_zone.realm[each.value].zone_id
+  zone_id  = local.kingdom.zone_id
   name     = local.mail-server == "" ? "@" : local.mail-server
   type     = "TXT"
   ttl      = 172800
@@ -31,9 +31,9 @@ resource "aws_route53_record" "crm-code" {
 }
 
 resource "aws_route53_record" "crm-dkim" {
-  for_each = toset(local.records-for-kingdoms)
+  for_each = toset(local.configuration.sdlc.environments)
   provider = aws.root
-  zone_id  = data.aws_route53_zone.realm[each.value].zone_id
+  zone_id  = local.kingdom.zone_id
   name     = "mail._domainkey.${local.mail-server}"
   type     = "TXT"
   ttl      = 172800
@@ -41,9 +41,9 @@ resource "aws_route53_record" "crm-dkim" {
 }
 
 resource "aws_route53_record" "crm-dmarc" {
-  for_each = toset(local.records-for-kingdoms)
+  for_each = toset(local.configuration.sdlc.environments)
   provider = aws.root
-  zone_id  = data.aws_route53_zone.realm[each.value].zone_id
+  zone_id  = local.kingdom.zone_id
   name     = "_dmarc.${local.mail-server}"
   type     = "TXT"
   ttl      = 172800


### PR DESCRIPTION
## 👨🏽‍💻 Description

These changes add the DNS records to validate Mail Service. This will allow us to validate the domain names with the CRM Provider via authentication from their side.

## ✅ Testing

- [x] Provisioned the infrastructure to development 
- [x] Confirm the records were created in Route53
- [x] Validation runs successful from the CRM Provider

## 🖼️ Evidence

Following screenshot shows the records created in AWS Route53:
![image](https://github.com/user-attachments/assets/0f869bc5-64fe-473e-8b22-8093fa3aa01f)

Following screenshot shows the successful authentication from the CRM Provider:
![image](https://github.com/user-attachments/assets/c74edae9-b913-40db-864b-4f39b72d70aa)
